### PR TITLE
Adding scripts to help building the split repositories

### DIFF
--- a/scripts/ethbuild.sh
+++ b/scripts/ethbuild.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# author: Lefteris Karapetsas <lefteris@refu.co>
+#
+# A script to build the different ethereum repositories. For usage look
+# at the string echoed in the very beginning.
+
+PROJECTS=(cpp-ethereum webthree solidity alethzero mix)
+ROOT_DIR=$(pwd)
+
+# Check arguments
+if  [[ $# -lt 1 ]]; then
+    echo "Wrong number of arguments!"
+    echo "Usage: ethbuild.sh branchname [extra-options]"
+    echo "    If --clean-build is given then build directories will be cleared"
+    echo "    If --build-type BUILDTYPE is given then this is gonna be the value of -DCMAKE_BUILD_TYPE"
+    echo "    If --cores NUMBER is give then this is the value to the cores argument of make. e.g.: make -j4"
+    exit 1
+fi
+
+REQUESTED_BRANCH=$1
+CLEAN_BUILD=0
+BUILD_TYPE=RelWithDebInfo
+REQUESTED_ARG=""
+EXTRA_BUILD_ARGS=""
+MAKE_CORES=1
+
+for arg in ${@:2}
+do
+    if [[ ${REQUESTED_ARG} != "" ]]; then
+	case $REQUESTED_ARG in
+	    "build-type")
+		BUILD_TYPE=$arg
+		;;
+	    "make-cores")
+		re='^[0-9]+$'
+		if ! [[ $arg =~ $re ]] ; then
+		    echo "ERROR: Value for --cores is not a number!"
+		    exit 1
+		fi
+		MAKE_CORES=$arg
+		;;
+	    *)
+		echo "ERROR: Unrecognized argument \"$arg\".";
+		exit 1
+	esac
+	REQUESTED_ARG=""
+	continue
+    fi
+    if [[ $arg == "--clean-build" ]]; then
+	CLEAN_BUILD=1
+	continue
+    fi
+
+    if [[ $arg == "--build-type" ]]; then
+	REQUESTED_ARG="build-type"
+	continue
+    fi
+
+    if [[ $arg == "--cores" ]]; then
+	REQUESTED_ARG="make-cores"
+	continue
+    fi
+
+    # all other arguments will just be given as it to cmake
+    EXTRA_BUILD_ARGS+=$arg
+    REQUESTED_ARG=""
+done
+
+if [[ ${REQUESTED_ARG} != "" ]]; then
+    echo "ERROR: Expected value for the \"${REQUESTED_ARG}\" argument";
+    exit 1
+fi
+
+for project in "${PROJECTS[@]}"
+do
+    cd $project >/dev/null 2>/dev/null
+    if [[ $? -ne 0 ]]; then
+	echo "Skipping ${project} because directory does not exit";
+	# Go back to root directory
+	cd $ROOT_DIR
+	continue
+    fi
+    BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
+    BRANCH="(unnamed branch)"     # detached HEAD
+    BRANCH=${BRANCH##refs/heads/}
+
+    if [[ $BRANCH != $REQUESTED_BRANCH ]]; then
+    	echo "BUILD WARNING: ${project} was in ${BRANCH} branch, while building on ${REQUESTED_BRANCH} was requested.";
+    	git checkout $REQUESTED_BRANCH
+    	if [[ $? -ne 0 ]]; then
+    	    echo "ERROR: Checking out branch ${REQUESTED_BRANCH} for ${project} failed";
+    	    exit 1
+    	fi
+    fi
+
+    # Make/clean build directory depending on requested arguments
+    if [[ -d "build" ]]; then
+    	if [[ $CLEAN_BUILD -eq 1 ]]; then
+    	    rm -rf build
+	    mkdir build
+    	fi
+    else
+    	mkdir build
+    fi
+
+    # Go in build directory for the project and confiure
+    cd build
+    cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $EXTRA_BUILD_ARGS;
+    if [[ $? -ne 0 ]]; then
+    	echo "ERROR: cmake configure phase for project \"$project\" failed.";
+    	exit 1
+    fi
+
+    # Build the project
+    make -j${MAKE_CORES}
+    if [[ $? -ne 0 ]]; then
+    	echo "ERROR: Building project \"$project\" failed.";
+    	exit 1
+    fi
+    # Go back to root directory
+    cd $ROOT_DIR
+done

--- a/scripts/ethbuild.sh
+++ b/scripts/ethbuild.sh
@@ -7,14 +7,18 @@
 PROJECTS=(cpp-ethereum webthree solidity alethzero mix)
 ROOT_DIR=$(pwd)
 
+function print_help {
+	echo "Usage: ethupdate.sh [options]"
+	echo "    --branch NAME Will update to the specified branch."
+	echo "    --origin NAME Will send the updates back to origin NAME if specified."
+	echo "    --upstream NAME The name of the remote to pull from."
+}
+
 # Check arguments
 if  [[ $# -lt 1 ]]; then
-    echo "Wrong number of arguments!"
-    echo "Usage: ethbuild.sh branchname [extra-options]"
-    echo "    If --clean-build is given then build directories will be cleared"
-    echo "    If --build-type BUILDTYPE is given then this is gonna be the value of -DCMAKE_BUILD_TYPE"
-    echo "    If --cores NUMBER is give then this is the value to the cores argument of make. e.g.: make -j4"
-    exit 1
+	echo "Wrong number of arguments!"
+	print_help
+	exit 1
 fi
 
 REQUESTED_BRANCH=$1
@@ -26,97 +30,99 @@ MAKE_CORES=1
 
 for arg in ${@:2}
 do
-    if [[ ${REQUESTED_ARG} != "" ]]; then
+	if [[ ${REQUESTED_ARG} != "" ]]; then
 	case $REQUESTED_ARG in
-	    "build-type")
-		BUILD_TYPE=$arg
+		"build-type")
+			BUILD_TYPE=$arg
 		;;
-	    "make-cores")
-		re='^[0-9]+$'
-		if ! [[ $arg =~ $re ]] ; then
-		    echo "ERROR: Value for --cores is not a number!"
-		    exit 1
-		fi
-		MAKE_CORES=$arg
-		;;
-	    *)
-		echo "ERROR: Unrecognized argument \"$arg\".";
-		exit 1
+		"make-cores")
+			re='^[0-9]+$'
+			if ! [[ $arg =~ $re ]] ; then
+				echo "ERROR: Value for --cores is not a number!"
+				exit 1
+			fi
+			MAKE_CORES=$arg
+			;;
+		*)
+			echo "ERROR: Unrecognized argument \"$arg\".";
+			print_help
+			exit 1
 	esac
 	REQUESTED_ARG=""
 	continue
-    fi
-    if [[ $arg == "--clean-build" ]]; then
-	CLEAN_BUILD=1
-	continue
-    fi
+	fi
 
-    if [[ $arg == "--build-type" ]]; then
-	REQUESTED_ARG="build-type"
-	continue
-    fi
+	if [[ $arg == "--clean-build" ]]; then
+		CLEAN_BUILD=1
+		continue
+	fi
 
-    if [[ $arg == "--cores" ]]; then
-	REQUESTED_ARG="make-cores"
-	continue
-    fi
+	if [[ $arg == "--build-type" ]]; then
+		REQUESTED_ARG="build-type"
+		continue
+	fi
 
-    # all other arguments will just be given as it to cmake
-    EXTRA_BUILD_ARGS+=$arg
-    REQUESTED_ARG=""
+	if [[ $arg == "--cores" ]]; then
+		REQUESTED_ARG="make-cores"
+		continue
+	fi
+
+	# all other arguments will just be given as they are to cmake
+	EXTRA_BUILD_ARGS+=$arg
+	REQUESTED_ARG=""
 done
 
 if [[ ${REQUESTED_ARG} != "" ]]; then
-    echo "ERROR: Expected value for the \"${REQUESTED_ARG}\" argument";
-    exit 1
+	echo "ERROR: Expected value for the \"${REQUESTED_ARG}\" argument";
+	exit 1
 fi
 
 for project in "${PROJECTS[@]}"
 do
-    cd $project >/dev/null 2>/dev/null
-    if [[ $? -ne 0 ]]; then
-	echo "Skipping ${project} because directory does not exit";
+	cd $project >/dev/null 2>/dev/null
+	if [[ $? -ne 0 ]]; then
+		echo "Skipping ${project} because directory does not exit";
+		# Go back to root directory
+		cd $ROOT_DIR
+		continue
+	fi
+	BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
+	BRANCH="(unnamed branch)"	  # detached HEAD
+	BRANCH=${BRANCH##refs/heads/}
+
+	if [[ $BRANCH != $REQUESTED_BRANCH ]]; then
+		echo "BUILD WARNING: ${project} was in ${BRANCH} branch, while building on ${REQUESTED_BRANCH} was requested.";
+		git checkout $REQUESTED_BRANCH
+		if [[ $? -ne 0 ]]; then
+			echo "ERROR: Checking out branch ${REQUESTED_BRANCH} for ${project} failed";
+			exit 1
+		fi
+	fi
+
+	# Make/clean build directory depending on requested arguments
+	if [[ -d "build" ]]; then
+		if [[ $CLEAN_BUILD -eq 1 ]]; then
+			rm -rf build
+			mkdir build
+		fi
+	else
+		mkdir build
+	fi
+
+	# Go in build directory for the project and configure
+	cd build
+	cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $EXTRA_BUILD_ARGS;
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR: cmake configure phase for project \"$project\" failed.";
+		exit 1
+	fi
+
+	# Build the project
+	make -j${MAKE_CORES}
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR: Building project \"$project\" failed.";
+		exit 1
+	fi
 	# Go back to root directory
 	cd $ROOT_DIR
-	continue
-    fi
-    BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
-    BRANCH="(unnamed branch)"     # detached HEAD
-    BRANCH=${BRANCH##refs/heads/}
-
-    if [[ $BRANCH != $REQUESTED_BRANCH ]]; then
-    	echo "BUILD WARNING: ${project} was in ${BRANCH} branch, while building on ${REQUESTED_BRANCH} was requested.";
-    	git checkout $REQUESTED_BRANCH
-    	if [[ $? -ne 0 ]]; then
-    	    echo "ERROR: Checking out branch ${REQUESTED_BRANCH} for ${project} failed";
-    	    exit 1
-    	fi
-    fi
-
-    # Make/clean build directory depending on requested arguments
-    if [[ -d "build" ]]; then
-    	if [[ $CLEAN_BUILD -eq 1 ]]; then
-    	    rm -rf build
-	    mkdir build
-    	fi
-    else
-    	mkdir build
-    fi
-
-    # Go in build directory for the project and confiure
-    cd build
-    cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $EXTRA_BUILD_ARGS;
-    if [[ $? -ne 0 ]]; then
-    	echo "ERROR: cmake configure phase for project \"$project\" failed.";
-    	exit 1
-    fi
-
-    # Build the project
-    make -j${MAKE_CORES}
-    if [[ $? -ne 0 ]]; then
-    	echo "ERROR: Building project \"$project\" failed.";
-    	exit 1
-    fi
-    # Go back to root directory
-    cd $ROOT_DIR
 done

--- a/scripts/ethupdate.sh
+++ b/scripts/ethupdate.sh
@@ -13,6 +13,7 @@ do
     cd $project >/dev/null 2>/dev/null
     if [[ $? -ne 0 ]]; then
 	echo "Skipping ${project} because directory does not exit";
+	cd $ROOT_DIR
 	continue
     fi
     BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
@@ -20,6 +21,7 @@ do
     BRANCH=${BRANCH##refs/heads/}
     if [[ $BRANCH != "develop" ]]; then
 	echo "Not updating ${project} because it's not in the develop branch"
+	cd $ROOT_DIR
 	continue
     fi
 

--- a/scripts/ethupdate.sh
+++ b/scripts/ethupdate.sh
@@ -2,33 +2,103 @@
 # author: Lefteris Karapetsas <lefteris@refu.co>
 #
 # A script to update the different ethereum repositories to latest develop
-# Invoke from the root directory and make sure you have upstream set as the
-# canonical repository and origin as your fork
+# Invoke from the root directory and make sure you have the arguments set as explained
+# in the usage string.
 
 ROOT_DIR=$(pwd)
 PROJECTS=(cpp-ethereum cpp-ethereum-cmake webthree solidity alethzero mix)
+UPSTREAM=upstream
+ORIGIN=origin
+REQUESTED_BRANCH=develop
+REQUESTED_ARG=""
+
+function print_help {
+	echo "Usage: ethupdate.sh [options]"
+	echo "    --branch NAME Will update to the specified branch."
+	echo "    --origin NAME Will send the updates back to origin NAME if specified."
+	echo "    --upstream NAME The name of the remote to pull from."
+}
+
+for arg in ${@:1}
+do
+	if [[ ${REQUESTED_ARG} != "" ]]; then
+		case $REQUESTED_ARG in
+			"origin")
+				ORIGIN=$arg
+				;;
+			"upstream")
+				UPSTREAM=$arg
+				;;
+			"branch")
+				REQUESTED_BRANCH=$arg
+				;;
+			*)
+				echo "ERROR: Unrecognized argument \"$arg\".";
+				print_help
+				exit 1
+		esac
+		REQUESTED_ARG=""
+		continue
+	fi
+
+	if [[ $arg == "--branch" ]]; then
+		REQUESTED_ARG="branch"
+		continue
+	fi
+
+	if [[ $arg == "--origin" ]]; then
+		REQUESTED_ARG="origin"
+		continue
+	fi
+
+	if [[ $arg == "--upstream" ]]; then
+		REQUESTED_ARG="upstream"
+		continue
+	fi
+
+	echo "ERROR: Unrecognized argument \"$arg\".";
+	print_help
+	exit 1
+done
+
+if [[ ${REQUESTED_ARG} != "" ]]; then
+	echo "ERROR: Expected value for the \"${REQUESTED_ARG}\" argument";
+	exit 1
+fi
 
 for project in "${PROJECTS[@]}"
 do
-    cd $project >/dev/null 2>/dev/null
-    if [[ $? -ne 0 ]]; then
-	echo "Skipping ${project} because directory does not exit";
-	cd $ROOT_DIR
-	continue
-    fi
-    BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
-    BRANCH="(unnamed branch)"     # detached HEAD
-    BRANCH=${BRANCH##refs/heads/}
-    if [[ $BRANCH != "develop" ]]; then
-	echo "Not updating ${project} because it's not in the develop branch"
-	cd $ROOT_DIR
-	continue
-    fi
+	cd $project >/dev/null 2>/dev/null
+	if [[ $? -ne 0 ]]; then
+		echo "Skipping ${project} because directory does not exit";
+		cd $ROOT_DIR
+		continue
+	fi
+	BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
+		BRANCH="(unnamed branch)"     # detached HEAD
+	BRANCH=${BRANCH##refs/heads/}
+	if [[ $BRANCH != $REQUESTED_BRANCH ]]; then
+		echo "WARNING: Not updating ${project} because it's not in the ${REQUESTED_BRANCH} branch"
+		cd $ROOT_DIR
+		continue
+	fi
 
-    # Assuming origin is your fork and upstream is the canonical repository under the /ethereum domain
-    git pull upstream develop
-    git push origin develop
-    echo "${project} succesfully updated!"
-    # Go back to root directory
-    cd $ROOT_DIR
+	# Pull changes from what the user set as the upstream repository
+	git pull $UPSTREAM $REQUESTED_BRANCH
+	if [[ $? -ne 0 ]]; then
+		echo "ERROR: Pulling changes for project ${project} from ${UPSTREAM} into the ${REQUESTED_BRANCH} branch failed."
+		cd $ROOT_DIR
+		continue
+	fi
+	# If upstream and origin are not the same, push the changes back to origin
+	if [[ $UPSTREAM != $ORIGIN ]]; then
+		git push $ORIGIN $REQUESTED_BRANCH
+		if [[ $? -ne 0 ]]; then
+			echo "ERROR: Could not update origin ${ORIGIN} of project ${project} for the ${REQUESTED_BRANCH}."
+			cd $ROOT_DIR
+			continue
+		fi
+	fi
+	echo "${project} succesfully updated!"
+	cd $ROOT_DIR
 done

--- a/scripts/ethupdate.sh
+++ b/scripts/ethupdate.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# author: Lefteris Karapetsas <lefteris@refu.co>
+#
+# A script to update the different ethereum repositories to latest develop
+# Invoke from the root directory and make sure you have upstream set as the
+# canonical repository and origin as your fork
+
+ROOT_DIR=$(pwd)
+PROJECTS=(cpp-ethereum cpp-ethereum-cmake webthree solidity alethzero mix)
+
+for project in "${PROJECTS[@]}"
+do
+    cd $project >/dev/null 2>/dev/null
+    if [[ $? -ne 0 ]]; then
+	echo "Skipping ${project} because directory does not exit";
+	continue
+    fi
+    BRANCH="$(git symbolic-ref HEAD 2>/dev/null)" ||
+    BRANCH="(unnamed branch)"     # detached HEAD
+    BRANCH=${BRANCH##refs/heads/}
+    if [[ $BRANCH != "develop" ]]; then
+	echo "Not updating ${project} because it's not in the develop branch"
+	continue
+    fi
+
+    # Assuming origin is your fork and upstream is the canonical repository under the /ethereum domain
+    git pull upstream develop
+    git push origin develop
+    echo "${project} succesfully updated!"
+    # Go back to root directory
+    cd $ROOT_DIR
+done


### PR DESCRIPTION
Note: These are intended for use by us, the developers, so Windows is not really considered here.

I am using these 2 scripts to help with updating/building the repositories with the new split repo organization so I thought I should share them in case more people found them useful.
- `ethupdate.sh`: Helps with updating all repositories to develop
- `ethbuild.sh`: Helps building all repositories in order. Accepts build arguments and forwards to cmake and make.

Any feedback is greatly appreciated.  Hope they turn out to be useful.
