### PR TITLE
fixed windows build

### DIFF
--- a/FindEth.cmake
+++ b/FindEth.cmake
@@ -29,7 +29,8 @@ else()
 			PATHS ${CMAKE_LIBRARY_PATH}
 			PATH_SUFFIXES "lib${l}" "${l}" "lib${l}/Release" 
 			# libevmjit is nested...
-			"evmjit/libevmjit-cpp"
+			"evmjit/libevmjit" "evmjit/libevmjit/Release"
+			"evmjit/libevmjit-cpp" "evmjit/libevmjit-cpp/Release"
 			NO_DEFAULT_PATH
 		)
 	endforeach()

--- a/UseEth.cmake
+++ b/UseEth.cmake
@@ -103,6 +103,7 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 
 	if (${SUBMODULE} STREQUAL "evmjit")
 		# TODO: not sure if should use evmjit or evmjit-cpp
+		target_link_libraries(${TARGET} ${Eth_EVMJIT_LIBRARIES})
 		target_link_libraries(${TARGET} ${Eth_EVMJIT-CPP_LIBRARIES})
 	endif()
 


### PR DESCRIPTION
webthree with evmjit is building on windows. It's temporary required, I will fix it in one of the next prs.
